### PR TITLE
Remove the hard coded yt api key from the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Mixtube
 
-Mixtube is a web application that let you create queues of videos and automatically cross-fades them so that you get a continuous stream of music. The only compatible video provider for now is YouTube but more will be added.
+Mixtube is a web application that let you create queues of videos and automatically cross-fades them so that you get a
+continuous stream of music. The only compatible video provider for now is YouTube but more will be added.
 
 ## Getting started
 For now, the only way to try Mixtube is to clone the GitHub repo and visit the index page through a web server.
+You will also need your own YouTube Data API key set into the environment variable `MIXTUBE_YOUTUBE_API_KEY`.
 
 You need npm installed on your machine. Then execute:
 ```
 npm install
-npm run serve
+MIXTUBE_YOUTUBE_API_KEY=<your YouTube data api key> npm run serve
 ```
 
 The server should be running by now and you can access MixTube at https://localhost:3000

--- a/app/index.html
+++ b/app/index.html
@@ -300,6 +300,9 @@
 </div>
 
 <script src="scripts/app.js"></script>
+<script>
+  initMixtube({youtubeAPIKey: '<!-- @echo YOUTUBE_API_KEY -->'});
+</script>
 <script src="https://www.youtube.com/iframe_api" defer></script>
 
 </body>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -3,21 +3,28 @@
 var angular = require('angular'),
   mixtubeModule = require('./mixtubeModule');
 
-angular.module('mixtubeApp', [mixtubeModule])
-  .config(function($locationProvider) {
-    $locationProvider.html5Mode(true);
-  })
+function initMixtube(environment) {
 
-  .run(function($rootScope, $controller, configuration) {
-    // make sure the scope always has the props property
-    $rootScope.props = {};
+  angular
+    .module('mixtubeApp', [mixtubeModule])
+    .constant('environment', environment)
+    .config(function($locationProvider) {
+      $locationProvider.html5Mode(true);
+    })
 
-    if (configuration.debug) {
-      $controller('DebuggingCtrl');
-    }
+    .run(function($rootScope, $controller, configuration) {
+      // make sure the scope always has the props property
+      $rootScope.props = {};
+
+      if (configuration.debug) {
+        $controller('DebuggingCtrl');
+      }
+    });
+
+  var $document = angular.element(document);
+  $document.ready(function() {
+    angular.bootstrap(document, ['mixtubeApp'], {strictDi: true});
   });
+}
 
-var $document = angular.element(document);
-$document.ready(function() {
-  angular.bootstrap(document, ['mixtubeApp'], {strictDi: true});
-});
+global.initMixtube = initMixtube;

--- a/app/scripts/components/configurationFactory.js
+++ b/app/scripts/components/configurationFactory.js
@@ -4,7 +4,7 @@ var has = require('lodash/object/has'),
   isUndefined = require('lodash/lang/isUndefined');
 
 // @ngInject
-function configurationFactory($location) {
+function configurationFactory($location, environment) {
 
   var locationSearch = $location.search();
   var debug = has(locationSearch, 'debug') && locationSearch.debug.trim().length > 0;
@@ -19,7 +19,7 @@ function configurationFactory($location) {
    */
   var configuration = {
     get youtubeAPIKey() {
-      return 'AIzaSyBg_Es1M1hmXUTXIj_FbjFu2MIOqpJFzZg';
+      return environment.youtubeAPIKey;
     },
     get maxSearchResults() {
       return 20;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ var path = require('path'),
   autoprefixer = require('autoprefixer-core'),
   csswring = require('csswring'),
   htmlreplace = require('gulp-html-replace'),
+  preprocess = require('gulp-preprocess'),
   svgSprite = require('gulp-svg-sprite'),
   replace = require('gulp-replace'),
   svg2png = require('gulp-svg2png'),
@@ -118,14 +119,12 @@ function buildInlineCss(opts) {
     });
 }
 
-function doHtml(opts) {
+function doHtml() {
   return gulp.src('app/index.html', {base: 'app'})
-    .pipe(htmlreplace({
-      cssInline: {
-        src: opts.inlineCssCode || '',
-        tpl: '<style>%s</style>'
-      },
-      favicons: opts.faviconsCode || ''
+    .pipe(preprocess({
+      context: {
+        YOUTUBE_API_KEY: 'AIzaSyBg_Es1M1hmXUTXIj_FbjFu2MIOqpJFzZg'
+      }
     }));
 }
 
@@ -202,13 +201,19 @@ gulp.task('js:dev', function() {
     watchifiedSrc('./app/scripts/components/capabilities/videoAutoPlayTest.js', './app/scripts/', pipelineFn));
 });
 
+gulp.task('html:dev', function() {
+  return doHtml()
+    .pipe(gulp.dest('build'));
+});
+
 gulp.task('clean:dev', function() {
   del('build');
 });
 
 gulp.task('serve', ['clean:dev', 'jshint'], function(done) {
-  runSequence(['css:dev', 'js:dev', 'svg:dev'], function() {
+  runSequence(['css:dev', 'js:dev', 'svg:dev', 'html:dev'], function() {
     gulp.watch('app/scripts/**/*.js', ['jshint']);
+    gulp.watch('app/index.html', ['html:dev']);
     gulp.watch('app/images/*.svg', ['svg:dev']);
     gulp.watch('app/styles/**/*.scss', ['css:dev']);
 
@@ -268,9 +273,17 @@ gulp.task('html:dist', function() {
         .pipe(doFaviconsStream);
     })])
     .then(function(codes) {
-      doHtml({inlineCssCode: codes[0], faviconsCode: codes[1]})
+      doHtml()
+        .pipe(htmlreplace({
+          cssInline: {
+            src: codes[0],
+            tpl: '<style>%s</style>'
+          },
+          favicons: codes[1]
+        }))
         .pipe(gulp.dest('dist'))
         .pipe(doHtmlStream);
+      remove_the_hard_coded_yt_api_key_from_the_configuration
     });
 
   return merge(doHtmlStream, doFaviconsStream);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,7 +123,7 @@ function doHtml() {
   return gulp.src('app/index.html', {base: 'app'})
     .pipe(preprocess({
       context: {
-        YOUTUBE_API_KEY: 'AIzaSyBg_Es1M1hmXUTXIj_FbjFu2MIOqpJFzZg'
+        YOUTUBE_API_KEY: process.env.MIXTUBE_YOUTUBE_API_KEY
       }
     }));
 }
@@ -283,7 +283,6 @@ gulp.task('html:dist', function() {
         }))
         .pipe(gulp.dest('dist'))
         .pipe(doHtmlStream);
-      remove_the_hard_coded_yt_api_key_from_the_configuration
     });
 
   return merge(doHtmlStream, doFaviconsStream);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-ng-annotate": "^1.0.0",
     "gulp-plumber": "^1.0.1",
     "gulp-postcss": "^5.1.8",
+    "gulp-preprocess": "^1.2.0",
     "gulp-replace": "^0.5.3",
     "gulp-sass": "^2.0.1",
     "gulp-sourcemaps": "^1.5.0",


### PR DESCRIPTION
#### What's this PR do?
Removes the YoutTube data API key from sources repo and uses the environment variable `MIXTUBE_YOUTUBE_API_KEY ` to retrieve it.

This change allows to have a different API per deployment / server and also keep the key "private" to the "deployer".
